### PR TITLE
work towards consolidation of SD-JWT terminology and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ For both use cases, the script expects a JSON file with settings (`settings.yml`
 Furthermore, the script expects, in its working directory, one subdirectory for each test case or example. In each such directory, there must be a file `specification.yml` with the test case or example specifications. Examples for these files can be found in the subdirectories of the [tests/testcases](tests/testcases) and [examples](examples) directories, respectively.
 
 The script outputs the following files in each test case or example directory:
- * `combined_issuance.txt`: The issuance format of the SD-JWT. (*)
- * `combined_presentation.txt`: The presentation format of the SD-JWT. (*)
+ * `sd_jwt_issuance.txt`: The issued SD-JWT. (*)
+ * `sd_jwt_presentation.txt`: The presented SD-JWT. (*)
  * `disclosures.md`: The disclosures, formatted as markdown (only in 'example' mode).
  * `user_claims.json`: The user claims.
  * `sd_jwt_payload.json`: The payload of the SD-JWT.
- * `sd_jwt_serialized.txt`: The serialized SD-JWT. (*)
+ * `sd_jwt_jws_part.txt`: The serialized JWS component of the SD-JWT. (*)
  * `kb_jwt_payload.json`: The payload of the key binding JWT.
  * `kb_jwt_serialized.txt`: The serialized key binding JWT.
  * `verified_contents.json`: The verified contents of the SD-JWT.

--- a/src/sd_jwt/bin/demo.py
+++ b/src/sd_jwt/bin/demo.py
@@ -165,7 +165,7 @@ def run():
 
     # Note: The only input from the issuer is the combined SD-JWT and SVC!
 
-    sdjwt_at_holder = SDJWTHolder(sdjwt_at_issuer.combined_sd_jwt_iid)
+    sdjwt_at_holder = SDJWTHolder(sdjwt_at_issuer.sd_jwt_issuance)
     sdjwt_at_holder.create_presentation(
         example["holder_disclosed_claims"],
         _args.nonce if example.get("key_binding", False) else None,
@@ -188,7 +188,7 @@ def run():
 
     # Note: The only input from the holder is the combined presentation!
     sdjwt_at_verifier = SDJWTVerifier(
-        sdjwt_at_holder.combined_presentation,
+        sdjwt_at_holder.sd_jwt_presentation,
         cb_get_issuer_key,
         settings.VERIFIER if example.get("key_binding", False) else None,
         _args.nonce if example.get("key_binding", False) else None,
@@ -217,14 +217,14 @@ def run():
     _artifacts = {
         "user_claims": (example["user_claims"], "User Claims", "json"),
         "sd_jwt_payload": (sdjwt_at_issuer.sd_jwt_payload, "Payload of the SD-JWT", "json"),
-        "sd_jwt_serialized": (
+        "sd_jwt_jws_part": (
             sdjwt_at_issuer.serialized_sd_jwt,
             "Serialized SD-JWT",
             "txt",
         ),
         "disclosures": (iid_payload, "Payloads of the II-Disclosures", "md"),
-        "combined_issuance": (
-            sdjwt_at_issuer.combined_sd_jwt_iid,
+        "sd_jwt_issuance": (
+            sdjwt_at_issuer.sd_jwt_issuance,
             "Combined SD-JWT and Disclosures",
             "txt",
         ),
@@ -240,8 +240,8 @@ def run():
             "Serialized Holder Binding JWT",
             "txt",
         ),
-        "combined_presentation": (
-            sdjwt_at_holder.combined_presentation,
+        "sd_jwt_presentation": (
+            sdjwt_at_holder.sd_jwt_presentation,
             "Combined representation of SD-JWT and HS-Disclosures",
             "txt",
         ),

--- a/src/sd_jwt/bin/generate.py
+++ b/src/sd_jwt/bin/generate.py
@@ -60,7 +60,7 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
     ### Produce SD-JWT-R for selected example
 
     sdjwt_at_holder = SDJWTHolder(
-        sdjwt_at_issuer.combined_sd_jwt_iid,
+        sdjwt_at_issuer.sd_jwt_issuance,
         serialization_format=serialization_format,
     )
     sdjwt_at_holder.create_presentation(
@@ -86,7 +86,7 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
             raise Exception(f"Unknown issuer: {issuer}")
 
     sdjwt_at_verifier = SDJWTVerifier(
-        sdjwt_at_holder.combined_presentation,
+        sdjwt_at_holder.sd_jwt_presentation,
         cb_get_issuer_key,
         settings["identifiers"]["verifier"]
         if testcase.get("key_binding", False)
@@ -111,18 +111,18 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
             "Payload of the SD-JWT",
             "json",
         ),
-        "sd_jwt_serialized": (
+        "sd_jwt_jws_part": (
             sdjwt_at_issuer.serialized_sd_jwt,
             "Serialized SD-JWT",
             "txt" if serialization_format == "compact" else "json",
         ),
-        "combined_issuance": (
-            sdjwt_at_issuer.combined_sd_jwt_iid,
+        "sd_jwt_issuance": (
+            sdjwt_at_issuer.sd_jwt_issuance,
             "Combined SD-JWT and Disclosures",
             "txt" if serialization_format == "compact" else "json",
         ),
-        "combined_presentation": (
-            sdjwt_at_holder.combined_presentation,
+        "sd_jwt_presentation": (
+            sdjwt_at_holder.sd_jwt_presentation,
             "Combined representation of SD-JWT and HS-Disclosures",
             "txt" if serialization_format == "compact" else "json",
         ),

--- a/src/sd_jwt/common.py
+++ b/src/sd_jwt/common.py
@@ -115,12 +115,7 @@ class SDJWTCommon:
         else:
             return
 
-    def _parse_sd_jwt(self, sd_jwt, is_holder=False):
-        # TODO: The 'is_holder' parameter is a temporary workaround for the
-        #       fact that the SD-JWT spec right now knows two different formats.
-        #       To be removed!
-        if self._serialization_format == "compact" and is_holder:
-            sd_jwt += "~"
+    def _parse_sd_jwt(self, sd_jwt):
 
         if self._serialization_format == "compact":
             (

--- a/src/sd_jwt/holder.py
+++ b/src/sd_jwt/holder.py
@@ -22,7 +22,7 @@ class SDJWTHolder(SDJWTCommon):
     def __init__(self, combined_sd_jwt_iid: str, serialization_format: str = "compact"):
         super().__init__(serialization_format=serialization_format)
 
-        self._parse_sd_jwt(combined_sd_jwt_iid, is_holder=True)
+        self._parse_sd_jwt(combined_sd_jwt_iid)
 
         # TODO: This holder does not verify the SD-JWT yet - this
         # is not strictly needed, but it would be nice to have.

--- a/src/sd_jwt/holder.py
+++ b/src/sd_jwt/holder.py
@@ -13,16 +13,16 @@ class SDJWTHolder(SDJWTCommon):
     key_binding_jwt_payload: Dict
     key_binding_jwt: JWS
     serialized_key_binding_jwt: str = ""
-    combined_presentation: str
+    sd_jwt_presentation: str
 
     _input_disclosures: List
     _hash_to_decoded_disclosure: Dict
     _hash_to_disclosure: Dict
 
-    def __init__(self, combined_sd_jwt_iid: str, serialization_format: str = "compact"):
+    def __init__(self, sd_jwt_issuance: str, serialization_format: str = "compact"):
         super().__init__(serialization_format=serialization_format)
 
-        self._parse_sd_jwt(combined_sd_jwt_iid)
+        self._parse_sd_jwt(sd_jwt_issuance)
 
         # TODO: This holder does not verify the SD-JWT yet - this
         # is not strictly needed, but it would be nice to have.
@@ -49,7 +49,7 @@ class SDJWTHolder(SDJWTCommon):
         if self._serialization_format == "compact":
             # Note: If the key binding JWT is not created, then the
             # last element is empty, matching the spec.
-            self.combined_presentation = self._combine(
+            self.sd_jwt_presentation = self._combine(
                 self.serialized_sd_jwt,
                 *self.hs_disclosures,
                 self.serialized_key_binding_jwt,
@@ -63,7 +63,7 @@ class SDJWTHolder(SDJWTCommon):
                 self.sd_jwt_parsed[
                     self.JWS_KEY_KB_JWT
                 ] = self.serialized_key_binding_jwt
-            self.combined_presentation = dumps(self.sd_jwt_parsed)
+            self.sd_jwt_presentation = dumps(self.sd_jwt_parsed)
 
     def _select_disclosures(self, sd_jwt_claims, claims_to_disclose):
         # Recursively process the claims in sd_jwt_claims. In each

--- a/src/sd_jwt/issuer.py
+++ b/src/sd_jwt/issuer.py
@@ -194,5 +194,6 @@ class SDJWTIssuer(SDJWTCommon):
             self.combined_sd_jwt_iid = self._combine(
                 self.serialized_sd_jwt, *(d.b64 for d in self.ii_disclosures)
             )
+            self.combined_sd_jwt_iid += self.COMBINED_serialization_FORMAT_SEPARATOR
         else:
             self.combined_sd_jwt_iid = self.serialized_sd_jwt

--- a/src/sd_jwt/issuer.py
+++ b/src/sd_jwt/issuer.py
@@ -24,7 +24,7 @@ class SDJWTIssuer(SDJWTCommon):
     serialized_sd_jwt: str
 
     ii_disclosures: List
-    combined_sd_jwt_iid: str
+    sd_jwt_issuance: str
 
     decoy_digests: List
 
@@ -191,9 +191,9 @@ class SDJWTIssuer(SDJWTCommon):
 
     def _create_combined(self):
         if self._serialization_format == "compact":
-            self.combined_sd_jwt_iid = self._combine(
+            self.sd_jwt_issuance = self._combine(
                 self.serialized_sd_jwt, *(d.b64 for d in self.ii_disclosures)
             )
-            self.combined_sd_jwt_iid += self.COMBINED_serialization_FORMAT_SEPARATOR
+            self.sd_jwt_issuance += self.COMBINED_serialization_FORMAT_SEPARATOR
         else:
-            self.combined_sd_jwt_iid = self.serialized_sd_jwt
+            self.sd_jwt_issuance = self.serialized_sd_jwt

--- a/src/sd_jwt/verifier.py
+++ b/src/sd_jwt/verifier.py
@@ -20,7 +20,7 @@ class SDJWTVerifier(SDJWTCommon):
 
     def __init__(
         self,
-        combined_presentation: str,
+        sd_jwt_presentation: str,
         cb_get_issuer_key: Callable[[str], str],
         expected_aud: Union[str, None] = None,
         expected_nonce: Union[str, None] = None,
@@ -28,7 +28,7 @@ class SDJWTVerifier(SDJWTCommon):
     ):
         super().__init__(serialization_format=serialization_format)
 
-        self._parse_sd_jwt(combined_presentation)
+        self._parse_sd_jwt(sd_jwt_presentation)
         self._create_hash_mappings(self._input_disclosures)
         self._verify_sd_jwt(cb_get_issuer_key)
 

--- a/tests/test_disclose_all_shortcut.py
+++ b/tests/test_disclose_all_shortcut.py
@@ -25,7 +25,7 @@ def test_e2e(testcase, settings):
         serialization_format=serialization_format,
     )
 
-    output_issuance = sdjwt_at_issuer.combined_sd_jwt_iid
+    output_issuance = sdjwt_at_issuer.sd_jwt_issuance
 
     # This test skips the holder's part and goes straight to the verifier.
     # To do so, we simply add a "~" to the issuance format, turning it into a presentation format.

--- a/tests/test_disclose_all_shortcut.py
+++ b/tests/test_disclose_all_shortcut.py
@@ -28,13 +28,8 @@ def test_e2e(testcase, settings):
     output_issuance = sdjwt_at_issuer.sd_jwt_issuance
 
     # This test skips the holder's part and goes straight to the verifier.
-    # To do so, we simply add a "~" to the issuance format, turning it into a presentation format.
-    # We also disable key binding checks.
-
-    if serialization_format == "compact":
-        output_holder = output_issuance + "~"
-    else:
-        output_holder = output_issuance
+    # We disable key binding checks.
+    output_holder = output_issuance
 
     # Verifier
     def cb_get_issuer_key(issuer):

--- a/tests/test_e2e_testcases.py
+++ b/tests/test_e2e_testcases.py
@@ -25,7 +25,7 @@ def test_e2e(testcase, settings):
         serialization_format=serialization_format,
     )
 
-    output_issuance = sdjwt_at_issuer.combined_sd_jwt_iid
+    output_issuance = sdjwt_at_issuer.sd_jwt_issuance
 
     # Holder
 
@@ -42,7 +42,7 @@ def test_e2e(testcase, settings):
         demo_keys["holder_key"] if testcase.get("key_binding", False) else None,
     )
 
-    output_holder = sdjwt_at_holder.combined_presentation
+    output_holder = sdjwt_at_holder.sd_jwt_presentation
 
     # Verifier
     def cb_get_issuer_key(issuer):


### PR DESCRIPTION
- Move towards SD-JWTs (issued or presented) always ending with a tilde 
- Update output file names to reflect the coming change that the whole structure (issued or presented) can simply be called an SD-JWT