### PR TITLE
omit _sd_alg and add flag for default claims

### DIFF
--- a/src/sd_jwt/bin/generate.py
+++ b/src/sd_jwt/bin/generate.py
@@ -100,10 +100,12 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
     verified = sdjwt_at_verifier.get_verified_payload()
 
     # Write the test case data to the directory of the test case
+    user_claims = remove_sdobj_wrappers(testcase["user_claims"])
+    user_claims = {key: value for key, value in user_claims.items() if value is not None}
 
     _artifacts = {
         "user_claims": (
-            remove_sdobj_wrappers(testcase["user_claims"]),
+            user_claims,
             "User Claims",
             "json",
         ),

--- a/src/sd_jwt/bin/generate.py
+++ b/src/sd_jwt/bin/generate.py
@@ -38,15 +38,17 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
     testcase = load_yaml_specification(testcase_path)
     use_decoys = testcase.get("add_decoy_claims", False)
     serialization_format = testcase.get("serialization_format", "compact")
+    include_default_claims = testcase.get("include_default_claims", True)
 
-    claims = {
-        "iss": settings["identifiers"]["issuer"],
-        "iat": settings["iat"],
-        "exp": settings["exp"],
-    }
+    claims = {}
+    if include_default_claims:
+        claims = {
+            "iss": settings["identifiers"]["issuer"],
+            "iat": settings["iat"],
+            "exp": settings["exp"],
+        }
 
     claims.update(testcase["user_claims"])
-    claims = {key: value for key, value in claims.items() if value is not None}
 
     ### Produce SD-JWT and SVC for selected example
     SDJWTIssuer.unsafe_randomness = True
@@ -100,12 +102,10 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
     verified = sdjwt_at_verifier.get_verified_payload()
 
     # Write the test case data to the directory of the test case
-    user_claims = remove_sdobj_wrappers(testcase["user_claims"])
-    user_claims = {key: value for key, value in user_claims.items() if value is not None}
 
     _artifacts = {
         "user_claims": (
-            user_claims,
+            remove_sdobj_wrappers(testcase["user_claims"]),
             "User Claims",
             "json",
         ),

--- a/src/sd_jwt/bin/generate.py
+++ b/src/sd_jwt/bin/generate.py
@@ -46,6 +46,7 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
     }
 
     claims.update(testcase["user_claims"])
+    claims = {key: value for key, value in claims.items() if value is not None}
 
     ### Produce SD-JWT and SVC for selected example
     SDJWTIssuer.unsafe_randomness = True
@@ -80,7 +81,7 @@ def generate_test_case_data(settings: Dict, testcase_path: Path, type: str):
     # matching public key
     def cb_get_issuer_key(issuer):
         # Do not use in production - this allows to use any issuer name for demo purposes
-        if issuer == claims["iss"]:
+        if issuer == claims.get("iss", None):
             return demo_keys["issuer_public_key"]
         else:
             raise Exception(f"Unknown issuer: {issuer}")

--- a/src/sd_jwt/verifier.py
+++ b/src/sd_jwt/verifier.py
@@ -56,7 +56,7 @@ class SDJWTVerifier(SDJWTCommon):
         parsed_input_sd_jwt = JWS()
         parsed_input_sd_jwt.deserialize(self._unverified_input_sd_jwt)
 
-        unverified_issuer = self._unverified_input_sd_jwt_payload["iss"]
+        unverified_issuer = self._unverified_input_sd_jwt_payload.get("iss", None)
         issuer_public_key = cb_get_issuer_key(unverified_issuer)
         parsed_input_sd_jwt.verify(issuer_public_key, alg=sign_alg)
 

--- a/src/sd_jwt/verifier.py
+++ b/src/sd_jwt/verifier.py
@@ -138,7 +138,7 @@ class SDJWTVerifier(SDJWTCommon):
             pre_output = {
                 k: self._unpack_disclosed_claims(v)
                 for k, v in sd_jwt_claims.items()
-                if k != SD_DIGESTS_KEY
+                if k != SD_DIGESTS_KEY and k != DIGEST_ALG_KEY
             }
 
             for digest in sd_jwt_claims.get(SD_DIGESTS_KEY, []):

--- a/tests/test_disclose_all_shortcut.py
+++ b/tests/test_disclose_all_shortcut.py
@@ -47,7 +47,6 @@ def test_e2e(testcase, settings):
     # We here expect that the output claims are the same as the input claims
     expected_claims = remove_sdobj_wrappers(testcase["user_claims"])
     expected_claims["iss"] = settings["identifiers"]["issuer"]
-    expected_claims["_sd_alg"] = "sha-256"
 
     if testcase.get("key_binding", False):
         expected_claims["cnf"] = {"jwk": demo_keys["holder_key"].export_public(as_dict=True)}

--- a/tests/test_e2e_testcases.py
+++ b/tests/test_e2e_testcases.py
@@ -61,7 +61,6 @@ def test_e2e(testcase, settings):
 
     expected_claims = testcase["expect_verified_user_claims"]
     expected_claims["iss"] = settings["identifiers"]["issuer"]
-    expected_claims["_sd_alg"] = "sha-256"
 
     if testcase.get("key_binding", False):
         expected_claims["cnf"] = {


### PR DESCRIPTION
omit _sd_alg from the verified payload contents  (related to https://github.com/oauth-wg/oauth-selective-disclosure-jwt/issues/313)

allowing i.e. iat, iss, exp to be omitted on a per example basis with an include_default_claims flag that itself defaults to true in the specification.yml (to have something for https://github.com/oauth-wg/oauth-selective-disclosure-jwt/issues/312)